### PR TITLE
fix bug: .bss section not written

### DIFF
--- a/assembler/examples/bug-tests/bss-section/bug11-bss-section.s
+++ b/assembler/examples/bug-tests/bss-section/bug11-bss-section.s
@@ -1,0 +1,44 @@
+# Bug 11 Test: BSS Section Not Written to Output
+# Issue: .bss section is collected but never written to output
+# Expected: Uninitialized data should be zero-filled in output
+# Actual: .bss section ignored, references point to wrong addresses
+
+.text
+.org 0x0020
+main:
+    # Load address of BSS variable
+    la x1, bss_var1
+    la x2, bss_var2
+    la x3, bss_var3
+    
+    # Load values from BSS (should be zero)
+    lw x4, 0(x1)    # Should load 0x0000
+    lw x5, 0(x2)    # Should load 0x0000
+    lw x6, 0(x3)    # Should load 0x0000
+    
+    # Store some values to BSS
+    li x7, 0x1234
+    sw x7, 0(x1)    # Store to bss_var1
+    
+    li x0, 0x5678
+    sw x0, 0(x2)    # Store to bss_var2
+    
+    li x1, 0x9ABC
+    sw x1, 0(x3)    # Store to bss_var3
+    
+    # Load back to verify
+    lw x2, 0(x1)   # Should load 0x1234
+    lw x3, 0(x2)   # Should load 0x5678
+    lw x4, 0(x3)   # Should load 0x9ABC
+    
+    ecall 0x00A     # Exit
+
+.data
+.org 0x8000
+data_var: .word 0xDEAD
+
+.bss
+.org 0x9000
+bss_var1: .space 4    # 4 bytes of uninitialized data
+bss_var2: .space 8    # 8 bytes of uninitialized data  
+bss_var3: .space 16   # 16 bytes of uninitialized data 

--- a/assembler/examples/bug-tests/bss-section/test_bss.py
+++ b/assembler/examples/bug-tests/bss-section/test_bss.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import sys
+sys.path.append('assembler')
+from zx16asm import ZX16Assembler
+
+# Test the BSS section fix
+assembler = ZX16Assembler()
+
+with open('assembler/examples/bug-tests/bug11-bss-section.s', 'r') as f:
+    source = f.read()
+
+success = assembler.assemble(source, 'bug11-bss-section.s')
+
+print("Assembly success:", success)
+print("BSS section size:", len(assembler.sections['.bss']))
+print("BSS section content:", assembler.sections['.bss'].hex())
+print("BSS section address:", assembler.section_addresses['.bss'])
+
+# Generate binary output
+binary_output = assembler.get_binary_output()
+print("Binary output size:", len(binary_output))
+print("BSS section in binary (0x9000-0x901C):", binary_output[0x9000:0x901C].hex()) 


### PR DESCRIPTION
- Added BSS section writing to get_binary_output() function
- Added BSS section support to Intel HEX output format
- Added BSS section support to Verilog output format
- Added BSS section support to memory file output format
- Updated listing output to include BSS section statistics
- Added test case demonstrating BSS section functionality
- Added test script to verify BSS section collection and output

The BSS section is now properly zero-filled and written to all output formats, ensuring uninitialized data variables have correct addresses and zero values. This PR fixes #44 
